### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date" />
 </picture>
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -134,9 +134,9 @@ The project is divided into **Fundamentals** and **Practice** sections, correspo
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=datawhalechina/easy-vecdb&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=datawhalechina/easy-vecdb&type=Date" />
 </picture>
 </div>
 


### PR DESCRIPTION
The Star History chart in the README is currently broken due to GitHub stargazer API restrictions on the previous provider. This change updates the chart links in both README.md and README_en.md to a working source that needs no API token, so the chart renders correctly again.